### PR TITLE
Update Dockerfile node to 19 version

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -9,7 +9,7 @@ COPY go .
 RUN go build -o onlineconf-admin
 
 
-FROM node:18
+FROM node:19
 
 WORKDIR /usr/src/onlineconf-admin
 


### PR DESCRIPTION
This merge request caused by deprecated libraries update 
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/43151027/212052591-e426ca71-7075-4923-85fc-aeaf8cba58bc.png">
after the update, I conducted manual tests, everything worked as intended