### PR TITLE
admin: rpm does not need ExtUtils::MakeMaker for build

### DIFF
--- a/admin/SPECS/onlineconf-admin.spec
+++ b/admin/SPECS/onlineconf-admin.spec
@@ -19,7 +19,6 @@ Group:          MAILRU
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 BuildRequires:  mr-rpm-macros
-BuildRequires:  perl(ExtUtils::MakeMaker)
 BuildRequires:  golang
 BuildRequires:  golang-bin
 BuildRequires:  nodejs


### PR DESCRIPTION
I don't see why it would be needed on build ? 